### PR TITLE
fix cancelling alarm and disable screen rotate.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
 
         <activity
             android:name=".views.MainActivity"
+            android:screenOrientation="portrait"
             android:label="@string/app_name"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar.FullScreen">
             <intent-filter>

--- a/app/src/main/java/com/yasinhajiloo/washhandsreminder/views/MainActivity.java
+++ b/app/src/main/java/com/yasinhajiloo/washhandsreminder/views/MainActivity.java
@@ -152,8 +152,11 @@ public class MainActivity extends AppCompatActivity {
                 mAlarmMode = AlarmMode.OFF;
                 mSharedViewModel.setDataTime(0);
                 mSharedViewModel.setAlarmStatus(false);
-                if (alarmManager != null)
-                    alarmManager.cancel(MyAlarmManager.getPendingIntent(getApplicationContext(), PENDING_ID, PendingIntent.FLAG_UPDATE_CURRENT));
+                if (alarmManager != null){
+                    PendingIntent pendingIntent = MyAlarmManager.getPendingIntent(getApplicationContext(), PENDING_ID, PendingIntent.FLAG_UPDATE_CURRENT);
+                    alarmManager.cancel(pendingIntent);
+                    pendingIntent.cancel();
+                }
                 break;
 
             // current state it's off so we should turn on the alarm


### PR DESCRIPTION
![Capture+_2020-06-03-12-53-15](https://user-images.githubusercontent.com/15872932/83639554-1605bc80-a5c0-11ea-8988-a49e582b51e6.png)

this bug occurs in some earlier version of android that i tested (5.1 and 8).
I enabled and disabled alarm then closed the app from task manager then opened it again.

in earlier version of android when calling alarmManager.cancel() , it removes registered PendingIntent in AlarmManager's cache/meta data files but pendingIntent is still alive and it doesn't became null.
you should call cancel method on both (alarmManager and pendingIntent).



also I disable screen rotation because it doesn't have suitable design for landscape mode.